### PR TITLE
fix(config): simplify production DB config and use inline job adapter

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -74,12 +74,8 @@ test:
 # URL environment variable explicitly:
 #
 production:
-  primary:
-    url: <%= ENV["DATABASE_URL"] %>
-    pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
-  queue:
-    url: <%= ENV["DATABASE_URL"] %> 
-    pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
+  url: <%= ENV["DATABASE_URL"] %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
 #
 # Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
 # for a full overview on how database connection configuration can be specified.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
   config.cache_store = :solid_cache_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
-  config.active_job.queue_adapter = :solid_queue
+  config.active_job.queue_adapter = :inline
   config.solid_queue.connects_to = { database: { writing: :queue } }
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
fix(config): simplify production DB config and use inline job adapter

- Use DATABASE_URL directly for production DB connection
- Removed Solid Queue database configs (queue/cache/cable)
- Set ActiveJob adapter to :inline in production to avoid missing queue DB
- Allows weekly_report rake task to run on Heroku staging without errors